### PR TITLE
Fix syntax errors

### DIFF
--- a/main.php
+++ b/main.php
@@ -92,7 +92,6 @@ $time_delta = $time_end - $time_start;
 
 echo "Time: $time_delta\n";
 echo "Memory: $mem_delta\n";
-echo;
 
 #### 
 
@@ -114,4 +113,3 @@ $time_delta = $time_end - $time_start;
 
 echo "Time: $time_delta\n";
 echo "Memory: $mem_delta\n";
-echo;


### PR DESCRIPTION
```
$ php -l main.php        
PHP Parse error:  syntax error, unexpected token ";" in main.php on line 95
Errors parsing main.php
```
```
$ php -v         
PHP 8.3.3 (cli) (built: Feb 13 2024 15:41:14) (NTS gcc x86_64)
Copyright (c) The PHP Group
Zend Engine v4.3.3, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.3, Copyright (c), by Zend Technologies
```
